### PR TITLE
Switch AID to F043525950544F, handle wallet:address NDEF requests

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-07T07:56:58.963496Z">
+        <DropdownSelection timestamp="2025-07-06T08:01:48.711300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=1C121FDEE003VE" />

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Go to Android Settings → Connections → NFC and enable it.
 ### Key Components
 
 - **WalletManager**: Detects installed wallets and manages address storage
-- **CardService**: NFC Host Card Emulation using proprietary AID `D2760000850101`
+- **CardService**: NFC Host Card Emulation using proprietary AID `F043525950544F`
 - **Connection Manager**: Handles guided wallet opening with deep links and user instructions
 - **MainActivity**: Modern Jetpack Compose UI with real-time status updates
 
 ### NFC Protocol
 
-- **AID**: `D2760000850101` (proprietary, non-payment card)
-- **Commands**: SELECT, GET (address), PAYMENT (EIP-681 URIs)
+- **AID**: `F043525950544F` (proprietary, non-payment card)
+- **Commands**: SELECT, PAYMENT (handles both EIP-681 URIs and wallet:address)
 - **Response**: Stored wallet address or fallback address
 
 ## 🌐 Supported Networks

--- a/app/src/main/java/com/example/nfcpingpong/MainActivity.kt
+++ b/app/src/main/java/com/example/nfcpingpong/MainActivity.kt
@@ -109,7 +109,7 @@ class MainActivity : ComponentActivity() {
             val result = cardEmulation.registerAidsForService(
                 component,
                 CardEmulation.CATEGORY_OTHER,
-                listOf("F2222222222222")
+                listOf("F043525950544F")
             )
             Log.d(TAG, "Dynamic AID registration result: $result")
             result
@@ -127,7 +127,7 @@ class MainActivity : ComponentActivity() {
         }
         
         // Check if our service is the default for the AID
-        val isDefault = cardEmulation.isDefaultServiceForAid(component, "D2760000850101")
+        val isDefault = cardEmulation.isDefaultServiceForAid(component, "F043525950544F")
         Log.d(TAG, "Is default service for AID: $isDefault")
         
         // Get list of registered AIDs for our service

--- a/app/src/main/res/xml/nfc_apduservice.xml
+++ b/app/src/main/res/xml/nfc_apduservice.xml
@@ -7,6 +7,6 @@
         android:description="@string/aid_demo_desc">
         <!-- Use a proper proprietary AID that won't conflict with payment cards -->
         <!-- Format: D27600xxxx... where D276 is registered for proprietary use -->
-        <aid-filter android:name="D2760000850101"/> <!-- 8 bytes, proprietary AID -->
+        <aid-filter android:name="F043525950544F"/> <!-- 8 bytes, proprietary AID -->
     </aid-group>
 </host-apdu-service>


### PR DESCRIPTION
- Updated AID to F043525950544F for both merchant-terminal and customer-android-app. This is F0 + CRYPTO from ASCII -> HEX.
- Instead of custom APDU commands send the NDEF string wallet:address to retrieve the users wallet address. This means other wallets can support this intent and return their address instead of doing something custom for this app.