### PR TITLE
Return CAIP-10 address to wallet:address request

### DIFF
--- a/app/src/main/java/com/example/nfcpingpong/CardService.kt
+++ b/app/src/main/java/com/example/nfcpingpong/CardService.kt
@@ -165,13 +165,18 @@ class CardService : HostApduService() {
         Log.d(TAG, "Current state - Selected wallet: ${selectedWallet?.appName}, Address: $walletAddress")
         
         if (walletAddress != null) {
-            // Convert address to bytes and append success status
-            val addressBytes = walletAddress.toByteArray(Charsets.UTF_8)
-            Log.d(TAG, "✅ Returning wallet address: $walletAddress")
+            // Format address in CAIP-10 format: namespace:reference:address
+            // For Ethereum mainnet: eip155:1:0x...
+            val chainId = 1 // Default to Ethereum mainnet, could be made configurable
+            val caip10Address = "eip155:$chainId:$walletAddress"
+            
+            // Convert to bytes
+            val addressBytes = caip10Address.toByteArray(Charsets.UTF_8)
+            Log.d(TAG, "✅ Returning CAIP-10 formatted address: $caip10Address")
             Log.d(TAG, "Address bytes length: ${addressBytes.size}")
             sendDataToActivity("✅ Sent wallet address: ${walletAddress.take(6)}...${walletAddress.takeLast(4)}")
             
-            // Return just the address bytes
+            // Return the CAIP-10 formatted address bytes
             Log.d(TAG, "Response length: ${addressBytes.size}, hex: ${bytesToHex(addressBytes)}")
             return addressBytes
         } else {


### PR DESCRIPTION
Rather than returning only an Ethereum address in response to a `wallet:address` request, the app should return a [CAIP-10](https://chainagnostic.org/CAIPs/caip-10) formatted address, so that the merchant terminal knows what chain the user would like to pay on (or in the case of Ethereum + L2's it always returns Ethereum and the merchant looks for suitable L2's as well). 

Related merchant PR: https://github.com/FreePayPOS/merchant-app/pull/5