### PR TITLE
Update AID

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Go to Android Settings → Connections → NFC and enable it.
 
 ### NFC Protocol
 
-- **AID**: `F043525950544F` (proprietary, non-payment card)
+- **AID**: `F046524545504159` (F0 + FREEPAY in Hex)
 - **Commands**: SELECT, PAYMENT (handles both EIP-681 URIs and wallet:address)
 - **Response**: Stored wallet address or fallback address
 

--- a/app/src/main/java/com/example/nfcpingpong/MainActivity.kt
+++ b/app/src/main/java/com/example/nfcpingpong/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity : ComponentActivity() {
             val result = cardEmulation.registerAidsForService(
                 component,
                 CardEmulation.CATEGORY_OTHER,
-                listOf("F043525950544F")
+                listOf("F046524545504159")
             )
             Log.d(TAG, "Dynamic AID registration result: $result")
             result
@@ -130,7 +130,7 @@ class MainActivity : ComponentActivity() {
         }
         
         // Check if our service is the default for the AID
-        val isDefault = cardEmulation.isDefaultServiceForAid(component, "F043525950544F")
+        val isDefault = cardEmulation.isDefaultServiceForAid(component, "F046524545504159")
         Log.d(TAG, "Is default service for AID: $isDefault")
         
         // Get list of registered AIDs for our service

--- a/app/src/main/java/com/example/nfcpingpong/MainActivity.kt
+++ b/app/src/main/java/com/example/nfcpingpong/MainActivity.kt
@@ -360,7 +360,7 @@ fun MainContent(
                     text = "1. Select your preferred wallet app.\n" +
                             "2. Copy your wallet address in the wallet app.\n" +
                             "3. Paste your wallet address into FreePay.\n\n" +
-                          "FreePay must be running in the background when tapping a FreePay POS terminal for payment.",
+                          "FreePay may need to be running in the background when tapping a FreePay POS terminal for payment.",
                     style = MaterialTheme.typography.bodyMedium
                 )
             }

--- a/app/src/main/res/xml/nfc_apduservice.xml
+++ b/app/src/main/res/xml/nfc_apduservice.xml
@@ -5,8 +5,6 @@
 
     <aid-group android:category="other"
         android:description="@string/aid_demo_desc">
-        <!-- Use a proper proprietary AID that won't conflict with payment cards -->
-        <!-- Format: D27600xxxx... where D276 is registered for proprietary use -->
-        <aid-filter android:name="F043525950544F"/> <!-- 8 bytes, proprietary AID -->
+        <aid-filter android:name="F046524545504159"/> <!-- 8 bytes, F0 + FREEPAY in Hex -->
     </aid-group>
 </host-apdu-service>


### PR DESCRIPTION
I've recently discovered that AID's should be unique for apps. I originally thought all wallets would share an AID and then the FreePay POS terminal would use that and the phone would appear with a selector but some phones won't do this when there are duplicate AID's. 

So instead I'm now making FreePay have its own AID of 0F + FREEPAY in HEX, and the terminal will first search for that, and then cycle through other known AID's of other wallets and prompt them if the FreePay wallet isn't found. 

FreePay also doesn't have to be running to do tap to pay, it just has to be installed, so I've updated the instructions that it may be required to be running in the background. 